### PR TITLE
Tenx speed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rhdf5
 Type: Package
 Title: HDF5 interface to R
-Version: 2.23.1
+Version: 2.23.1.1
 Authors@R: c(person("Bernd", "Fischer", role = c("aut")), 
         person("Gregoire", "Pau", role="aut"),
         person("Mike", "Smith", role=c("aut", "cre"), email = "mike.smith@embl.de"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rhdf5
 Type: Package
 Title: HDF5 interface to R
-Version: 2.21.6
+Version: 2.23.1
 Authors@R: c(person("Bernd", "Fischer", role = c("aut")), 
         person("Gregoire", "Pau", role="aut"),
         person("Mike", "Smith", role=c("aut", "cre"), email = "mike.smith@embl.de"))

--- a/R/h5read.R
+++ b/R/h5read.R
@@ -52,7 +52,15 @@ h5readDataset <- function (h5dataset, index = NULL, start = NULL, stride = NULL,
       tmp = unique(sort(index[[i]]))
       I[[i]] = match(index[[i]], tmp)
     }
-    obj <- do.call("[", c(list(obj), I, drop = FALSE))
+    #####################
+    ## This can take a long time for large datasets
+    ## can we find rules for skipping it? 
+    #obj <- do.call("[", c(list(obj), I, drop = FALSE))
+    obj.dim <- lapply(dim(obj), FUN = seq_len)
+    if(!identical(I, obj.dim)) {
+        obj <- do.call("[", c(list(obj), I, drop = FALSE))
+    } 
+    ####################
   }
   try({
     H5Sclose(h5spaceFile)

--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ Package Homepage: http://bioconductor.org/packages/devel/bioc/html/rhdf5.html
 Bug Reports: https://support.bioconductor.org/p/new/post/?tag_val=rhdf5.
 
 
+## Funding 
+
+Funding for continued development and maintenance of this package is provided by the German Network for Bioinformatics Infrastructure
+
+<a href="http://www.denbi.de"><img src="https://tess.elixir-europe.org/system/content_providers/images/000/000/063/original/deNBI_Logo_rgb.jpg" width="400" align="left"></a>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # rhdf5
 
-This R/Bioconductor package provides an interface between HDF5 and R. 
-HDF5's main features are the ability to store and access very large and/or complex datasets and a wide variety of metadata on mass storage (disk) through a completely portable file format. The rhdf5 package is thus suited
-for the exchange of large and/or complex datasets between R and other software package, and for letting R applications work on datasets that are larger than the available RAM.
+This R/Bioconductor package provides an interface between HDF5 and R. HDF5's main features are the ability to store and access very large and/or complex datasets and a wide variety of metadata on mass storage (disk) through a completely portable file format. The rhdf5 package is thus suited for the exchange of large and/or complex datasets between R and other software package, and for letting R applications work on datasets that are larger than the available RAM.
 
 ## Current Status
 
@@ -12,8 +10,7 @@ for the exchange of large and/or complex datasets between R and other software p
 
 ## Contact
 
-Package Homepage: http://bioconductor.org/packages/devel/bioc/html/rhdf5.html 
-Bug Reports: https://support.bioconductor.org/p/new/post/?tag_val=rhdf5.
+For bug reports, please register an [issue](https://github.com/grimbough/rhdf5/issues) here on Github. For usage queries please post a question on the [Bioconductor Support Forum](https://support.bioconductor.org/p/new/post/?tag_val=rhdf5).
 
 
 ## Funding 


### PR DESCRIPTION
There is a `do.call` in `h5readDataset` that takes a subset of an object.  This appears to result in a memory copy even if the subset is the entirety of the original object.  This patch adds logical to check whether we really need to subset, or can just use the original as is, in which case the mem-copy doesn't occur and things work more quickly.