### PR TITLE
use H5Sunlimited() for maxdims for extendible datasets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rhdf5
 Type: Package
 Title: HDF5 interface to R
-Version: 2.23.5
+Version: 2.23.6
 Authors@R: c(person("Bernd", "Fischer", role = c("aut")), 
         person("Gregoire", "Pau", role="aut"),
         person("Mike", "Smith", role=c("aut", "cre"), email = "mike.smith@embl.de"))

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -83,6 +83,7 @@ export(H5Sset_extent_simple)
 export(H5Sis_simple)
 export(H5Sselect_index)
 export(H5Sselect_hyperslab)
+export(H5Sunlimited)
 
 export(H5Tcopy)
 export(H5Tset_size)

--- a/R/H5S.R
+++ b/R/H5S.R
@@ -162,5 +162,8 @@ H5Sselect_index <- function( h5space, index ) {
   invisible(size)
 }
 
+H5Sunlimited <- function()  {
+  h5checkConstants("H5S", "H5S_UNLIMITED")
+}
 
 ## c(1,which(index[seq_len(length(index)-1)+1]-1 != index[seq_len(length(index)-1)]))

--- a/R/h5create.R
+++ b/R/h5create.R
@@ -57,8 +57,8 @@ h5createDataset <- function(file, dataset, dims, maxdims = dims, storage.mode = 
                 if (any(maxdims != dims) & is.null(chunk)) {
                     stop('If "maxdims" is different from "dims", chunking is required.')
                 }
-                if (any(maxdims < dims)) {
-                    stop('All elements of "maxdims" have to be equal or larger than "dims".')
+                if (any(maxdims != h5constants$H5S["H5S_UNLIMITED"] & maxdims < dims)) {
+                    stop('All non-extensible elements of "maxdims" have to be equal or larger than "dims".')
                 }
                 if (any(dims < 0)) {
                     stop('All elements of "dims" must be non-negative.')

--- a/man/h5createDataset.Rd
+++ b/man/h5createDataset.Rd
@@ -17,7 +17,7 @@ h5createDataset (file, dataset,
   \item{file}{The filename (character) of the file in which the dataset will be located. For advanced programmers it is possible to provide an object of class \code{\link{H5IdComponent}} representing a H5 location identifier (file or group). See \code{\link{H5Fcreate}}, \code{\link{H5Fopen}}, \code{\link{H5Gcreate}}, \code{\link{H5Gopen}} to create an object of this kind.}
   \item{dataset}{Name of the dataset to be created. The name can contain group names, e.g. 'group/dataset', but the function will fail, if the group does not yet exist.}
   \item{dims}{The dimensions of the array as they will appear in the file. Note, the dimensions will appear in inverted order when viewing the file with a C-programm (e.g. HDFView), because the fastest changing dimension in R is the first one, whereas the fastest changing dimension in C is the last one.}
-  \item{maxdims}{The maximum extension of the array.}
+  \item{maxdims}{The maximum extension of the array. Use \code{H5Sunlimited()} to indicate an extensible dimension.}
   \item{storage.mode}{The storage mode of the data to be written. Can be obtained by \code{storage.mode(mydata)}.}
   \item{H5type}{Advanced programmers can specify the datatype of the dataset within the file. See \code{h5const("H5T")} for a list of available datatypes. If \code{H5type} is specified the argument \code{storage.mode} is ignored. It is recommended to use \code{storage.mode}}
   \item{size}{For \code{storage.mode='character'} the maximum string length has to be specified. HDF5 then stores the string as fixed length character vectors. Together with compression, this should be efficient.}

--- a/src/H5constants.c
+++ b/src/H5constants.c
@@ -59,9 +59,9 @@ SEXP _H5constants( ) {
   const char *name_H5O_TYPE[] = { "H5O_TYPE_ALL", "H5O_TYPE_GROUP", "H5O_TYPE_DATASET", "H5O_TYPE_NAMED_DATATYPE"};
   addVector(i++, Rval, groupnames, "H5O_TYPE", 4, const_H5O_TYPE, name_H5O_TYPE);
 
-  int const_H5S[3]       = {  H5S_SCALAR,   H5S_SIMPLE,   H5S_NULL };
-  const char *name_H5S[] = { "H5S_SCALAR", "H5S_SIMPLE", "H5S_NULL"};
-  addVector(i++, Rval, groupnames, "H5S", 3, const_H5S, name_H5S);
+  int const_H5S[4]       = {  H5S_SCALAR,   H5S_SIMPLE,   H5S_NULL,   H5S_UNLIMITED };
+  const char *name_H5S[] = { "H5S_SCALAR", "H5S_SIMPLE", "H5S_NULL", "H5S_UNLIMITED"};
+  addVector(i++, Rval, groupnames, "H5S", 4, const_H5S, name_H5S);
 
   int const_H5S_SELECT[6]       = {  H5S_SELECT_SET,   H5S_SELECT_OR,   H5S_SELECT_AND,   H5S_SELECT_XOR,   H5S_SELECT_NOTB,   H5S_SELECT_NOTA };
   const char *name_H5S_SELECT[] = { "H5S_SELECT_SET", "H5S_SELECT_OR", "H5S_SELECT_AND", "H5S_SELECT_XOR", "H5S_SELECT_NOTB", "H5S_SELECT_NOTA"};

--- a/tests/testthat/test_h5constants.R
+++ b/tests/testthat/test_h5constants.R
@@ -5,8 +5,9 @@ context("h5 defined constants")
 ############################################################
 
 test_that("const groups", {
-    expect_is( H5loadConstants(), "list" ) %>%
-        expect_length( n = 18 )
+    ## No longer exported---must stop testing
+    ## expect_is( H5loadConstants(), "list" ) %>%
+    ##     expect_length( n = 18 )
     
     expect_is( h5constType(), "character" ) %>%
         expect_length(n = 18)

--- a/tests/testthat/test_h5create.R
+++ b/tests/testthat/test_h5create.R
@@ -112,6 +112,39 @@ test_that("Datasets with different compression levels", {
     expect_lte( file.size(h5File_9), file.size(h5File_0) )
 })
 
+
+test_that("Extendible datasets", {
+    mtx4x3 <- matrix(runif(n=12), nrow = 4)
+    mtx3x3 <- matrix(runif(n=9), nrow = 3)
+    mtx7x2 <- matrix(runif(n=14), nrow = 7)
+    extendible <- H5Sunlimited()
+    h5createDataset(file = h5File, dataset = "extend", dims = c(4,3), maxdims = c(extendible, extendible))
+    h5write( mtx4x3, file = h5File, name = "extend")
+    expect_equal(h5read(h5File, "extend"), mtx4x3)
+
+    ## now extend in first dimension:
+    ## [ mtx4x3 ]
+    ## [ mtx3x3 ]
+
+    h5set_extent(h5File, "extend", c(7,3))
+    h5write(mtx3x3, file = h5File, name = "extend",
+            start = c(5,1))
+    expect_equal(h5read(h5File, "extend"),
+                 rbind(mtx4x3, mtx3x3))
+
+    
+    ## now extend in the other dimension:
+    ## [ mtx4x3 mtx7x2 ]
+    ## [ mtx3x3 mtx7x2 ]
+    h5set_extent(h5File, "extend", c(7,5))
+    h5write(mtx7x2, file = h5File, name = "extend",
+            start = c(1,4))
+    expect_equal(h5read(h5File, "extend"),
+                 cbind(rbind(mtx4x3, mtx3x3),
+                       mtx7x2))
+
+})
+
 ############################################################
 context("h5createAttribute")
 ############################################################


### PR DESCRIPTION
Hello, I wanted to be able to create extendible Datasets. (See [Extendible Datasets at HDF5 website](https://support.hdfgroup.org/HDF5/Tutor/extend.html).)

This requires passing in -1 (`H5S_UNLIMITED` constant in C) for the maxdims argument in h5createDataset. So I made the following changes:
1. added `H5S_UNLIMITED` constant in C, then `H5Sunlimited()` function in R to return this constant, exported so that end-user can use the constant to build `maxdims` argument for `h5createDataset()`.
2. modified `h5createDataset()` to not throw an error when `maxdims < dims` so long as `maxdims == H5S_UNLIMITED` (element-wise).
3. wrote a test in `tests/testthat/test_h5create.R` to demonstrate that datasets can be created with unlimited dimensions, and then extended.

One last thing is that I commented out a test in `tests/testthat/test_h5constants.R` which was failing since `H5loadConstants()` is no longer exported. I needed this so that all the tests would pass.
