### PR TITLE
h5set_extent/H5Dset_extent support extending dimensions beyond 2^31

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rhdf5
 Type: Package
 Title: HDF5 interface to R
-Version: 2.25.4
+Version: 2.25.5
 Authors@R: c(person("Bernd", "Fischer", role = c("aut")), 
         person("Gregoire", "Pau", role="aut"),
         person("Mike", "Smith", role=c("aut", "cre"), email = "mike.smith@embl.de"),

--- a/R/H5D.R
+++ b/R/H5D.R
@@ -112,7 +112,7 @@ H5Dwrite <- function( h5dataset, buf, h5spaceMem=NULL, h5spaceFile=NULL ) {
 
 H5Dset_extent <- function( h5dataset, size) {
   h5checktype(h5dataset, "dataset")
-  size <- as.integer(size)
+  size <- as.numeric(size)
   if (!h5dataset@native) size <- rev(size)
   invisible(.Call("_H5Dset_extent", h5dataset@ID, size, PACKAGE='rhdf5'))
 }

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -1097,7 +1097,7 @@ SEXP _H5Dset_extent( SEXP _dataset_id, SEXP _size ) {
   if (rank > 0) {
     hsize_t size[rank];
     for (int i=0; i < rank; i++) {
-      size[i] = INTEGER(_size)[i];
+      size[i] = (hsize_t) REAL(_size)[i];
     }
     herr = H5Dset_extent( dataset_id, size );
   } else {


### PR DESCRIPTION
Hi Mike,

Right now, `h5set_extent`/`H5Dset_extent` fail to extend dimensions beyond 2^31:
```
library(rhdf5)
tmpfile <- tempfile()
h5createFile(tmpfile)
h5createDataset(tmpfile, "A", dims=0, maxdims=3e9, storage.mode="integer", chunk=16384)

h5ls(tmpfile, all=TRUE)[c("dim", "maxdim")]
#   dim     maxdim
# 0   0 3000000000

h5set_extent(tmpfile, "A", dims=1e9)
h5ls(tmpfile, all=TRUE)[c("dim", "maxdim")]
#          dim     maxdim
# 0 1000000000 3000000000

h5set_extent(tmpfile, "A", dims=2e9)
h5ls(tmpfile, all=TRUE)[c("dim", "maxdim")]
#          dim     maxdim
# 0 2000000000 3000000000

h5set_extent(tmpfile, "A", dims=3e9)
# Error in H5Dset_extent(did, dims) : 
#   HDF5. Dataset. Unable to initialize object.
# In addition: Warning message:
# In H5Dset_extent(did, dims) : NAs introduced by coercion to integer range
h5ls(tmpfile, all=TRUE)[c("dim", "maxdim")]
#          dim     maxdim
# 0 2000000000 3000000000
```
The change I propose is straightforward.

Thanks!
H.

```
> sessionInfo()
R version 3.5.1 Patched (2018-08-01 r75051)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Ubuntu 16.04.5 LTS

Matrix products: default
BLAS: /home/hpages/R/R-3.5.r75051/lib/libRblas.so
LAPACK: /home/hpages/R/R-3.5.r75051/lib/libRlapack.so

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C              
 [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
 [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8   
 [7] LC_PAPER=en_US.UTF-8       LC_NAME=C                 
 [9] LC_ADDRESS=C               LC_TELEPHONE=C            
[11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] rhdf5_2.25.4

loaded via a namespace (and not attached):
[1] compiler_3.5.1 Rhdf5lib_1.3.1
```