### PR TITLE
Improved handling of 64bit integers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rhdf5
 Type: Package
 Title: HDF5 interface to R
-Version: 2.25.9
+Version: 2.25.10
 Authors@R: c(person("Bernd", "Fischer", role = c("aut")), 
         person("Gregoire", "Pau", role="aut"),
         person("Mike", "Smith", role=c("aut", "cre"), email = "mike.smith@embl.de"),

--- a/R/H5D.R
+++ b/R/H5D.R
@@ -84,9 +84,9 @@ H5Dread <- function( h5dataset, h5spaceFile=NULL, h5spaceMem=NULL, buf = NULL, c
   if (missing(bit64conversion)) {
     bit64conv = 0L
   } else {
-    bit64conv = switch(bit64conversion, int = 1L,double = 2L,bit64 = 3L,default=0L)
+    bit64conv = switch(bit64conversion, int = 0L, double = 1L, bit64 = 2L, default = 0L)
   }
-  if (bit64conv == 3L) {
+  if (bit64conv == 2L) {
     if (!requireNamespace("bit64",quietly=TRUE)) {
       stop("install package 'bit64' before using bit64conversion='bit64'")
     }

--- a/R/h5create.R
+++ b/R/h5create.R
@@ -104,6 +104,7 @@ h5createDataset <- function(file, dataset, dims, maxdims = dims, storage.mode = 
                             tid <- switch(storage.mode[1],
                                           double = h5constants$H5T["H5T_NATIVE_DOUBLE"],
                                           integer = h5constants$H5T["H5T_NATIVE_INT32"],
+                                          integer64 = h5constants$H5T["H5T_NATIVE_INT64"],
                                           logical = h5constants$H5T["H5T_NATIVE_INT32"],
                                           character = {
                                               tid <- H5Tcopy("H5T_C_S1")
@@ -113,7 +114,8 @@ h5createDataset <- function(file, dataset, dims, maxdims = dims, storage.mode = 
                                               H5Tset_size(tid, size)
                                               tid
                                           },
-                                          { stop("datatype ",storage.mode," not yet implemented. Try 'double', 'integer', or 'character'.") } )
+                                          { stop("datatype ",storage.mode, " not yet implemented.\n", 
+                                                 "Try 'logical', 'double', 'integer', 'integer64' or 'character'.") } )
                         } else {
                             stop("Can not create dataset. 'storage.mode' has to be a character.")
                         }

--- a/R/h5read.R
+++ b/R/h5read.R
@@ -71,7 +71,9 @@ h5readDataset <- function (h5dataset, index = NULL, start = NULL, stride = NULL,
     obj
 }
 
-h5read <- function(file, name, index=NULL, start=NULL, stride=NULL, block=NULL, count=NULL, compoundAsDataFrame = TRUE, callGeneric = TRUE, read.attributes=FALSE, drop = FALSE, ..., native = FALSE) {
+h5read <- function(file, name, index=NULL, start=NULL, stride=NULL, block=NULL,
+                   count = NULL, compoundAsDataFrame = TRUE, callGeneric = TRUE,
+                   read.attributes=FALSE, drop = FALSE, ..., native = FALSE) {
     
     loc = h5checktypeOrOpenLoc(file, readonly=TRUE, native = native)
     on.exit( h5closeitLoc(loc) )

--- a/R/h5write.R
+++ b/R/h5write.R
@@ -3,183 +3,178 @@
 h5writeDatasetHelper <- function (obj, h5dataset, index = NULL, start = NULL, stride = NULL, 
                                   block = NULL, count = NULL)
 {
-  if (is.null(dim(obj))) {
-    dim(obj) = length(obj)
-  }
-  try({
-    h5spaceFile <- H5Dget_space(h5dataset)
-    on.exit(H5Sclose(h5spaceFile))
-  })
-
-  if (!is.null(index)) {
-    s = H5Sget_simple_extent_dims(h5spaceFile)$size
-    if (length(index) != length(s)) {
-      stop("length of index has to be equal to dimensional extension of HDF5 dataset.")
-    }
-    for (i in seq_len(length(index))) {
-      if (is.null(index[[i]])) {
-        index[[i]] = seq_len(s[i])
-      } else if( is.call(index[[i]] )) {
-          index[[i]] <- eval(index[[i]])
-      }
+    if (is.null(dim(obj))) {
+        dim(obj) = length(obj)
     }
     try({
-      H5Sselect_index(h5spaceFile, index)
+        h5spaceFile <- H5Dget_space(h5dataset)
+        on.exit(H5Sclose(h5spaceFile))
     })
-    d = sapply(index, length)
-    d[d == 0] = dim(obj)[d == 0]
-    dim(obj) = d
-    I = list()
-    for (i in seq_len(length(index))) {
-      m <- match(index[[i]], unique(sort(index[[i]])))
-      I[[i]] = order(m)
-      I[[i]] = I[[i]][!duplicated(m[I[[i]]], fromLast = TRUE)]
+    
+    if (!is.null(index)) {
+        s = H5Sget_simple_extent_dims(h5spaceFile)$size
+        if (length(index) != length(s)) {
+            stop("length of index has to be equal to dimensional extension of HDF5 dataset.")
+        }
+        for (i in seq_len(length(index))) {
+            if (is.null(index[[i]])) {
+                index[[i]] = seq_len(s[i])
+            } else if( is.call(index[[i]] )) {
+                index[[i]] <- eval(index[[i]])
+            }
+        }
+        try({
+            H5Sselect_index(h5spaceFile, index)
+        })
+        d = sapply(index, length)
+        d[d == 0] = dim(obj)[d == 0]
+        dim(obj) = d
+        I = list()
+        for (i in seq_len(length(index))) {
+            m <- match(index[[i]], unique(sort(index[[i]])))
+            I[[i]] = order(m)
+            I[[i]] = I[[i]][!duplicated(m[I[[i]]], fromLast = TRUE)]
+        }
+        obj <- do.call("[", c(list(obj), I))
     }
-    obj <- do.call("[", c(list(obj), I))
-  }
-  else {
-    if (any(c(!is.null(start), !is.null(stride), !is.null(block), 
-              !is.null(count)))) {
-      if (is.null(block) & is.null(count)) {
-        block = rep(1, length(dim(obj)))
-        count = dim(obj)
-      }
-      try({
-        H5Sselect_hyperslab(h5spaceFile, start = start, 
-                            stride = stride, count = count, block = block)
-      })
+    else {
+        if (any(c(!is.null(start), !is.null(stride), !is.null(block), 
+                  !is.null(count)))) {
+            if (is.null(block) & is.null(count)) {
+                block = rep(1, length(dim(obj)))
+                count = dim(obj)
+            }
+            try({
+                H5Sselect_hyperslab(h5spaceFile, start = start, 
+                                    stride = stride, count = count, block = block)
+            })
+        }
     }
-  }
-  DimMem <- dim(obj)
-  if (is.null(DimMem)) {
-    DimMem = length(obj)
-  }
-  try({
-    h5spaceMem <- H5Screate_simple(DimMem, NULL)
-    on.exit(H5Sclose(h5spaceMem), add = TRUE, after = FALSE)
-  })
-  try({
-    res <- H5Dwrite(h5dataset, obj, h5spaceMem = h5spaceMem, 
-                    h5spaceFile = h5spaceFile)
-  })
-  #try({
-  #  H5Sclose(h5spaceMem)
-  #})
-  #try({
-  #  H5Sclose(h5spaceFile)
-  #})
-  invisible(NULL)
+    DimMem <- dim(obj)
+    if (is.null(DimMem)) {
+        DimMem = length(obj)
+    }
+    try({
+        h5spaceMem <- H5Screate_simple(DimMem, NULL)
+        on.exit(H5Sclose(h5spaceMem), add = TRUE, after = FALSE)
+    })
+    try({
+        res <- H5Dwrite(h5dataset, obj, h5spaceMem = h5spaceMem, 
+                        h5spaceFile = h5spaceFile)
+    })
+
+    invisible(NULL)
 }
 
 
 h5write <- function(obj, file, name, ...) {
-  res <- UseMethod("h5write")
-  invisible(res)
+    res <- UseMethod("h5write")
+    invisible(res)
 }
 
 h5write.default <- function(obj, file, name, createnewfile=TRUE, write.attributes = FALSE, ..., native = FALSE) {
-  loc = h5checktypeOrOpenLoc(file, createnewfile = createnewfile, native = native)
-  on.exit(h5closeitLoc(loc))
-  
-  res <- h5writeDataset(obj, loc$H5Identifier, name, ...)
-  if (write.attributes) {
-    # type = H5Oget_info_by_name(loc$H5Identifier, name)$type
-    oid = H5Oopen(loc$H5Identifier, name)
-    type = H5Iget_type(oid)
-    H5Oclose(oid)
-
-    if (type == "H5I_GROUP") {
-      h5obj = H5Gopen(loc$H5Identifier, name)
-      on.exit(H5Gclose(h5obj), add = TRUE)
-    } else {
-      if (type == "H5I_DATASET") {
-        h5obj = H5Dopen(loc$H5Identifier, name)
-        on.exit(H5Dclose(h5obj), add = TRUE)
-      } else {
-        stop("Cannot open object of this type")
-      }
+    loc = h5checktypeOrOpenLoc(file, createnewfile = createnewfile, native = native)
+    on.exit(h5closeitLoc(loc))
+    
+    res <- h5writeDataset(obj, loc$H5Identifier, name, ...)
+    if (write.attributes) {
+        # type = H5Oget_info_by_name(loc$H5Identifier, name)$type
+        oid = H5Oopen(loc$H5Identifier, name)
+        type = H5Iget_type(oid)
+        H5Oclose(oid)
+        
+        if (type == "H5I_GROUP") {
+            h5obj = H5Gopen(loc$H5Identifier, name)
+            on.exit(H5Gclose(h5obj), add = TRUE)
+        } else {
+            if (type == "H5I_DATASET") {
+                h5obj = H5Dopen(loc$H5Identifier, name)
+                on.exit(H5Dclose(h5obj), add = TRUE)
+            } else {
+                stop("Cannot open object of this type")
+            }
+        }
+        Attr <- attributes(obj)
+        for (i in seq_len(length(Attr))) {
+            h5writeAttribute(Attr[[i]], h5obj, name = names(Attr)[i])
+        }
+        #if (type == "H5O_TYPE_GROUP") {
+        #  H5Gclose(h5obj)
+        #} else {
+        #  if (type == "H5O_TYPE_DATASET") {
+        #    H5Dclose(h5obj)
+        #  }
+        #}
     }
-    Attr <- attributes(obj)
-    for (i in seq_len(length(Attr))) {
-      h5writeAttribute(Attr[[i]], h5obj, name = names(Attr)[i])
-    }
-    #if (type == "H5O_TYPE_GROUP") {
-    #  H5Gclose(h5obj)
-    #} else {
-    #  if (type == "H5O_TYPE_DATASET") {
-    #    H5Dclose(h5obj)
-    #  }
-    #}
-  }
-
-  invisible(res)
+    
+    invisible(res)
 }
 
 h5writeDataset <- function(obj, h5loc, name, ...) {
-  h5checktype(h5loc, "loc")
-  res <- UseMethod("h5writeDataset")
-  invisible(res)
+    h5checktype(h5loc, "loc")
+    res <- UseMethod("h5writeDataset")
+    invisible(res)
 }
 
 h5writeDataset.data.frame <- function(obj, h5loc, name, level=7, DataFrameAsCompound = TRUE) {
-  if (DataFrameAsCompound) {
-    if (H5Lexists(h5loc, name)) {
-      stop("Cannot write data.frame. Object already exists. Subsetting for compound datatype not supported.")
-    }
-    if (!is.null(level)) { level = as.integer(level) }
-    .Call("_h5writeDataFrame", obj, h5loc@ID, name, level, PACKAGE='rhdf5')
-    res <- 0
-  } else {
-    a <- attr(obj,"names")
-    if (is.null(a)) {
-      attr(obj,"names") = sprintf("col%d",seq_len(ncol(obj)))
+    if (DataFrameAsCompound) {
+        if (H5Lexists(h5loc, name)) {
+            stop("Cannot write data.frame. Object already exists. Subsetting for compound datatype not supported.")
+        }
+        if (!is.null(level)) { level = as.integer(level) }
+        .Call("_h5writeDataFrame", obj, h5loc@ID, name, level, PACKAGE='rhdf5')
+        res <- 0
     } else {
-      if (any(duplicated(a))) {
-        a[duplicated(a)] = sprintf("col%d",seq_len(ncol(obj)))[duplicated(a)]
-        attr(obj,"names") = a
-      }
+        a <- attr(obj,"names")
+        if (is.null(a)) {
+            attr(obj,"names") = sprintf("col%d",seq_len(ncol(obj)))
+        } else {
+            if (any(duplicated(a))) {
+                a[duplicated(a)] = sprintf("col%d",seq_len(ncol(obj)))[duplicated(a)]
+                attr(obj,"names") = a
+            }
+        }
+        ## we can't write out factors, so convert any to character
+        colClass <- sapply(obj, is.factor)
+        if(any(colClass)) {
+            obj[,which(colClass)] <- as.character(obj[,which(colClass)])
+        }
+        
+        res <- h5writeDataset.list(obj=obj, h5loc=h5loc, name=name, level=level)
     }
-    ## we can't write out factors, so convert any to character
-    colClass <- sapply(obj, is.factor)
-    if(any(colClass)) {
-        obj[,which(colClass)] <- as.character(obj[,which(colClass)])
-    }
-    
-    res <- h5writeDataset.list(obj=obj, h5loc=h5loc, name=name, level=level)
-  }
-  invisible(res)
+    invisible(res)
 }
 
 h5writeDataset.list <- function(obj, h5loc, name, level=7) {
-  exists <- try( { H5Lexists(h5loc, name) } )
-  if (exists) {
-    message("Existing object within HDF5 file cannot be overwritten with a list object. First delete the group or dataset from the HDF5 file.")
-    res = 0
-  } else {
-    N = names(obj)
-    newnames = FALSE
-    if (is.null(N)) {
-      newnames = TRUE
+    exists <- try( { H5Lexists(h5loc, name) } )
+    if (exists) {
+        message("Existing object within HDF5 file cannot be overwritten with a list object. First delete the group or dataset from the HDF5 file.")
+        res = 0
     } else {
-      if (any(nchar(N) == 0)) {
-        newnames = TRUE
-      } else {
-        if (length(N) != length(obj)) {
-          newnames = TRUE
+        N = names(obj)
+        newnames = FALSE
+        if (is.null(N)) {
+            newnames = TRUE
+        } else {
+            if (any(nchar(N) == 0)) {
+                newnames = TRUE
+            } else {
+                if (length(N) != length(obj)) {
+                    newnames = TRUE
+                }
+            }
         }
-      }
+        if (newnames) {
+            N = sprintf("ELT%d",seq_len(length(obj)))
+        }
+        res = NULL
+        h5createGroup(h5loc, name)
+        gid = H5Gopen(h5loc, name)
+        for (i in seq_len(length(obj))) {
+            res = h5write(obj[[i]], gid, N[i])
+        }
+        H5Gclose(gid)
     }
-    if (newnames) {
-      N = sprintf("ELT%d",seq_len(length(obj)))
-    }
-    res = NULL
-    h5createGroup(h5loc, name)
-    gid = H5Gopen(h5loc, name)
-    for (i in seq_len(length(obj))) {
-      res = h5write(obj[[i]], gid, N[i])
-    }
-    H5Gclose(gid)
-  }
 }
 
 h5writeDataset.matrix <- function(...) { h5writeDataset.array(...) }
@@ -189,31 +184,31 @@ h5writeDataset.logical <- function(...) { h5writeDataset.array(...) }
 h5writeDataset.character <- function(...) { h5writeDataset.array(...) }
 
 h5writeDataset.array <- function(obj, h5loc, name, index = NULL, start=NULL, stride=NULL, block=NULL, count=NULL, size=NULL, level=7) {
-  if (is.null(dim(obj))) {
-    dim(obj) = length(obj)
-  }
-  exists <- try( { H5Lexists(h5loc, name) } )
-  if (!exists) {
-    if (is.null(size)) {
-      size = NULL
-      if (storage.mode(obj) == "character") {
-        if (length(obj) > 0) {
-          size = max(nchar(obj))+1
-        } else {
-          size = 1
-        }
-      }
-      dim <- dim(obj)
-      if (h5loc@native) dim <- rev(dim)
-      try( { h5createDataset(h5loc, name, dim, storage.mode = storage.mode(obj), size = size, chunk=dim, level=level) } )
+    if (is.null(dim(obj))) {
+        dim(obj) = length(obj)
     }
-  }
-  try ( { h5dataset <- H5Dopen(h5loc, name) } )
-  h5writeDatasetHelper(obj=obj, h5dataset=h5dataset, index = index, start = start, stride = stride, 
-                       block = block, count = count)
-  try( { H5Dclose(h5dataset) } )
-#  invisible(res)
-  invisible(NULL)
+    exists <- try( { H5Lexists(h5loc, name) } )
+    if (!exists) {
+        if (is.null(size)) {
+            size = NULL
+            if (storage.mode(obj) == "character") {
+                if (length(obj) > 0) {
+                    size = max(nchar(obj))+1
+                } else {
+                    size = 1
+                }
+            }
+            dim <- dim(obj)
+            if (h5loc@native) dim <- rev(dim)
+            try( { h5createDataset(h5loc, name, dim, storage.mode = storage.mode(obj), size = size, chunk=dim, level=level) } )
+        }
+    }
+    try ( { h5dataset <- H5Dopen(h5loc, name) } )
+    h5writeDatasetHelper(obj=obj, h5dataset=h5dataset, index = index, start = start, stride = stride, 
+                         block = block, count = count)
+    try( { H5Dclose(h5dataset) } )
+    #  invisible(res)
+    invisible(NULL)
 }
 
 

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -305,16 +305,16 @@ SEXP H5Dread_helper_INTEGER(hid_t dataset_id, hid_t file_space_id, hid_t mem_spa
         void* intbuf;
         if ((b < 4) | ((b == 4) & (sgn == H5T_SGN_2))) {
             dtypeNative = H5T_NATIVE_INT;
-            intbuf = malloc(sizeof(int) * n);
+            intbuf = R_alloc(n, sizeof(int));
         } else if ((b == 4) & (sgn == H5T_SGN_NONE)) {
             dtypeNative = H5T_NATIVE_UINT;
-            intbuf = malloc(sizeof(unsigned int) * n);
+            intbuf = R_alloc(n, sizeof(unsigned int));
         } else if ((b == 8) & (sgn == H5T_SGN_2)) {
             dtypeNative = H5T_NATIVE_INT64;
-            intbuf = malloc(sizeof(long long) * n);
+            intbuf = R_alloc(n, sizeof(long long));
         } else if ((b == 8) & (sgn == H5T_SGN_NONE)) {
             dtypeNative = H5T_NATIVE_UINT64;
-            intbuf = malloc(sizeof(unsigned long long) * n);
+            intbuf = R_alloc(n, sizeof(unsigned long long));
         }
         if (intbuf == 0) {
             error("Not enough memory to read data! Try to read a subset of data by specifying the index or count parameter.");
@@ -459,7 +459,6 @@ SEXP H5Dread_helper_INTEGER(hid_t dataset_id, hid_t file_space_id, hid_t mem_spa
                 UNPROTECT(1);
             }
         }
-        free(intbuf);
         if (length(_buf) == 0) {
             setAttrib(Rval, R_DimSymbol, Rdim);
         }
@@ -467,10 +466,10 @@ SEXP H5Dread_helper_INTEGER(hid_t dataset_id, hid_t file_space_id, hid_t mem_spa
     
     if ((warn > 0) | (warn_NA > 0) | (warn_double > 0)) {
         if (warn > 0) {
-            warning("NAs produced by integer overflow while converting 64-bit integer or unsigned 32-bit integer from HDF5 to a 32-bit integer in R. Choose bit64conversion='bit64' or bit64conversion='double' to avoid data loss and see the vignette 'rhdf5' for more details about 64-bit integers.");
+            warning("NAs produced by integer overflow while converting 64-bit integer or unsigned 32-bit integer from HDF5 to a 32-bit integer in R.\nChoose bit64conversion='bit64' or bit64conversion='double' to avoid data loss and see the vignette 'rhdf5' for more details about 64-bit integers.");
         } else {
             if (warn_double > 0) {
-                warning("integer precision lost while converting 64-bit integer or unsigned 32-bit integer from HDF5 to double in R. Choose bit64conversion='bit64' to avoid data loss and see the vignette 'rhdf5' for more details about 64-bit integers.");
+                warning("integer precision lost while converting 64-bit integer or unsigned 32-bit integer from HDF5 to double in R.\nChoose bit64conversion='bit64' to avoid data loss and see the vignette 'rhdf5' for more details about 64-bit integers.");
             } else {
                 if (bit64conversion == 2) {
                     warning("integer value -2^31 replaced by NA. See the section 'Large integer data types' in the 'rhdf5' vignette for more details.");
@@ -550,12 +549,12 @@ SEXP H5Dread_helper_STRING(hid_t dataset_id, hid_t file_space_id, hid_t mem_spac
             free(bufSTR[i]);
         }
     } else {
-        void* bufSTR = malloc(sizeof(char) * n * size);
+        void* bufSTR = R_alloc(n * size, sizeof(char));
         if (bufSTR == 0) {
             error("Not enough memory to read data! Try to read a subset of data by specifying the index or count parameter.");
         }
         herr_t herr = H5Dread(dataset_id, mem_type_id, mem_space_id, file_space_id, H5P_DEFAULT, bufSTR );
-        char* bufSTR2 = malloc(sizeof(char)*(size+1));
+        char* bufSTR2 = R_alloc(size + 1, sizeof(char));
         if (bufSTR2 == 0) {
             error("Not enough memory to read data! Try to read a subset of data by specifying the index or count parameter.");
         }
@@ -567,8 +566,6 @@ SEXP H5Dread_helper_STRING(hid_t dataset_id, hid_t file_space_id, hid_t mem_spac
             }
             SET_STRING_ELT(Rval, i, mkChar(bufSTR2));
         }
-        free(bufSTR);
-        free(bufSTR2);
     }
     
     if (native)
@@ -1030,6 +1027,7 @@ SEXP _H5Dwrite( SEXP _dataset_id, SEXP _buf, SEXP _file_space_id, SEXP _mem_spac
         buf = INTEGER(_buf);
         break;
     case REALSXP :
+        Rprintf("double\n");
         mem_type_id = H5T_NATIVE_DOUBLE;
         if (native)
             PERMUTE(_buf, REAL, dim_space_id);

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -1027,7 +1027,6 @@ SEXP _H5Dwrite( SEXP _dataset_id, SEXP _buf, SEXP _file_space_id, SEXP _mem_spac
         buf = INTEGER(_buf);
         break;
     case REALSXP :
-        Rprintf("double\n");
         mem_type_id = H5T_NATIVE_DOUBLE;
         if (native)
             PERMUTE(_buf, REAL, dim_space_id);

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -267,7 +267,7 @@ SEXP H5Dread_helper_INTEGER(hid_t dataset_id, hid_t file_space_id, hid_t mem_spa
     int warn = 0;
     int warn_double = 0;
     
-    if (((b < 4) | ((b == 4) & (sgn == H5T_SGN_2))) & (bit64conversion == 0)) {   // Read directly to R-integer without loss of data
+    if ((b < 4) | ((b == 4) & (sgn == H5T_SGN_2))) {   // Read directly to R-integer without loss of data (short or signed int)
         if (cpdType < 0) {
             mem_type_id = H5T_NATIVE_INT32;
         } else {
@@ -300,7 +300,7 @@ SEXP H5Dread_helper_INTEGER(hid_t dataset_id, hid_t file_space_id, hid_t mem_spa
         if (length(_buf) == 0) {
             setAttrib(Rval, R_DimSymbol, Rdim);
         }
-    } else {  // Convert data to R-integer and replace overflow values with NA_integer
+    } else { 
         hid_t dtypeNative;
         void* intbuf;
         if ((b < 4) | ((b == 4) & (sgn == H5T_SGN_2))) {
@@ -333,7 +333,7 @@ SEXP H5Dread_helper_INTEGER(hid_t dataset_id, hid_t file_space_id, hid_t mem_spa
         
         herr_t herr = H5Dread(dataset_id, mem_type_id, mem_space_id, file_space_id, H5P_DEFAULT, intbuf );
         
-        if (bit64conversion == 0) {
+        if (bit64conversion == 0) {  // Convert data to R-integer and replace overflow values with NA_integer
             void * buf;
             if (length(_buf) == 0) {
                 Rval = PROTECT(allocVector(INTSXP, n));
@@ -390,7 +390,7 @@ SEXP H5Dread_helper_INTEGER(hid_t dataset_id, hid_t file_space_id, hid_t mem_spa
                 buf = REAL(_buf);
                 Rval = _buf;
             }
-            if (bit64conversion == 2) {
+            if (bit64conversion == 1) {  //convert to double
                 long long i;
                 if ((b < 4) | ((b == 4) & (sgn == H5T_SGN_2))) {
                     for (i=0; i<n; i++){
@@ -422,7 +422,7 @@ SEXP H5Dread_helper_INTEGER(hid_t dataset_id, hid_t file_space_id, hid_t mem_spa
                         }
                     }
                 }
-            } else {
+            } else { // convert to integer64 class
                 long long i;
                 if ((b < 4) | ((b == 4) & (sgn == H5T_SGN_2))) {
                     for (i=0; i<n; i++){
@@ -1024,14 +1024,12 @@ SEXP _H5Dwrite( SEXP _dataset_id, SEXP _buf, SEXP _file_space_id, SEXP _mem_spac
     
     switch(TYPEOF(_buf)) {
     case INTSXP :
-        Rprintf("integer\n");
         mem_type_id = H5T_NATIVE_INT;
         if (native)
             PERMUTE(_buf, INTEGER, dim_space_id);
         buf = INTEGER(_buf);
         break;
     case REALSXP :
-        Rprintf("double\n");
         mem_type_id = H5T_NATIVE_DOUBLE;
         if (native)
             PERMUTE(_buf, REAL, dim_space_id);

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -1024,12 +1024,14 @@ SEXP _H5Dwrite( SEXP _dataset_id, SEXP _buf, SEXP _file_space_id, SEXP _mem_spac
     
     switch(TYPEOF(_buf)) {
     case INTSXP :
+        Rprintf("integer\n");
         mem_type_id = H5T_NATIVE_INT;
         if (native)
             PERMUTE(_buf, INTEGER, dim_space_id);
         buf = INTEGER(_buf);
         break;
     case REALSXP :
+        Rprintf("double\n");
         mem_type_id = H5T_NATIVE_DOUBLE;
         if (native)
             PERMUTE(_buf, REAL, dim_space_id);

--- a/tests/testthat/test_h5read.R
+++ b/tests/testthat/test_h5read.R
@@ -81,6 +81,68 @@ test_that("Error if asking for something that isn't there", {
     
 })
 
+############################################################
+context("64-bit conversion")
+############################################################
+
+## output file name
+h5File <- tempfile(pattern = "ex_read", fileext = ".h5")
+if(file.exists(h5File))
+    file.remove(h5File)
+
+# create file with integers of different types
+h5createFile(h5File)
+h5createDataset(h5File, "int32", dims=50, storage.mode="integer")
+h5createDataset(h5File, "int64", dims=50, storage.mode="integer64")
+h5createDataset(h5File, "uint32", dims=50, H5type = "H5T_NATIVE_UINT32")
+h5write(obj = 1:50, file = h5File, name = "int32")
+h5write(obj = 1:50, file = h5File, name = "int64")
+h5write(obj = 2^31 + 1:50, file = h5File, name = "uint32")
+
+test_that("Signed 32bit integers are unchanged for all conversion arguments", {
+    
+    expect_is(x1 <- h5read(h5File, name = "int32", bit64conversion = "int"), "array")
+    expect_equal(storage.mode(x1), "integer")
+    expect_is(x2 <- h5read(h5File, name = "int32", bit64conversion = "double"), "array")
+    expect_equal(storage.mode(x2), "integer")
+    expect_is(x3 <- h5read(h5File, name = "int32", bit64conversion = "bit64"), "array")
+    expect_equal(storage.mode(x3), "integer")
+    
+    expect_identical(x1, x2)
+    expect_identical(x1, x3)
+})
+
+test_that("signed 64-bit integers are converted", {
+    
+    expect_is(x1 <- h5read(h5File, name = "int64", bit64conversion = "int"), "array")
+    expect_equal(storage.mode(x1), "integer")
+    expect_is(x2 <- h5read(h5File, name = "int64", bit64conversion = "double"), "array")
+    expect_equal(storage.mode(x2), "double")
+    expect_is(x3 <- h5read(h5File, name = "int64", bit64conversion = "bit64"), "integer64")
+    expect_equal(storage.mode(x2), "double")
+    
+})
+
+test_that("Unsigned 32bit integers are converted to NA out of range", {
+    
+    expect_warning(x1 <- h5read(h5File, name = "uint32", bit64conversion = "int")) 
+    expect_true(all(is.na(x1)))
+})
+
+test_that("Unsigned 32bit integers are converted properly to double/bit64", {
+    
+    expect_is(x2 <- h5read(h5File, name = "uint32", bit64conversion = "double"), "array") 
+    expect_equal(storage.mode(x2), "double")
+    expect_equivalent(x2, 2^31 + 1:50)
+    
+    expect_is(x3 <- h5read(h5File, name = "uint32", bit64conversion = "bit64"), "integer64")
+    expect_equal(storage.mode(x3), "double")
+    expect_equal(class(x3), "integer64")
+    expect_true(all(x3 > 2^31))
+})
+
+############################################################
+
 test_that("No open HDF5 objects are left", {
     expect_equal( length(h5validObjects()), 0 )
 })

--- a/vignettes/rhdf5.Rmd
+++ b/vignettes/rhdf5.Rmd
@@ -305,6 +305,7 @@ file.size("myhdf5file.h5")
 *N.B. `h5delete()` does not explicitly traverse the tree to remove child nodes.  It only removes the named entry, and HDF5 will then remove child nodes if they are now orphaned.  Hence it won't delete child nodes if you have a more complex structure where a child node has multiple parents and only one of these is removed.*
 
 #64-bit integers
+
 **R** does not support a native datatype for 64-bit integers. All integers in **R** are
 32-bit integers. When reading 64-bit integers from a HDF5-file, you
 may run into troubles. `r Biocpkg("rhdf5")` is able to deal with 64-bit integers, but
@@ -324,7 +325,7 @@ There are three different ways of reading 64-bit integers in
 **R**. `H5Dread()` and `h5read()` have the argument
 `bit64conversion` the specify the conversion method.
 
-By setting {\bf `bit64conversion='int'`}, a coercing to 32-bit
+By setting `bit64conversion='int'`, a coercing to 32-bit
 integers is enforced, with the risk of data loss, but with the
 insurance that numbers are represented as native integers.
 


### PR DESCRIPTION
- Provides the option to write R-doubles as 64-bit integers in `h5create()` & `h5write()`
- No longer converts short ints and signed 32-bit ints when using `h5read()` and `bit64conversion = "double|bit64` - these stay as native R-integers.
- Fixed bug that would try to use `integer64` when `bit64conversion = "int"`