### PR TITLE
Update h5writeDataFrame.c

### DIFF
--- a/src/h5writeDataFrame.c
+++ b/src/h5writeDataFrame.c
@@ -21,7 +21,7 @@ SEXP _h5createDataFrame(SEXP _obj, SEXP _loc_id, SEXP _name, SEXP _level, SEXP _
                 s2 = LENGTH(STRING_ELT(VECTOR_ELT(_obj,i),j));
                 if (s2 > strsize[i]) { strsize[i] = s2; }
             }
-            strsize[i] = strsize[i] + 1;
+            if (strsize[i] == 0) { strsize[i] = 1; }
             size = size + strsize[i];
         }
     }
@@ -95,7 +95,7 @@ SEXP _h5writeDataFrame(SEXP _obj, SEXP _dset_id) {
                 s2 = LENGTH(STRING_ELT(VECTOR_ELT(_obj,i),j));
                 if (s2 > strsize[i]) { strsize[i] = s2; }
             }
-            strsize[i] = strsize[i] + 1;
+            if (strsize[i] == 0) { strsize[i] = 1; }
         }
     }
 
@@ -121,7 +121,7 @@ SEXP _h5writeDataFrame(SEXP _obj, SEXP _dset_id) {
             int z=0;
             int j;
             for (int k=0; k < LENGTH(VECTOR_ELT(_obj,i)); k++) {
-                for (j=0; (j < LENGTH(STRING_ELT(VECTOR_ELT(_obj,i),k))) & (j < (strsize[i]-1)); j++) {
+                for (j=0; (j < LENGTH(STRING_ELT(VECTOR_ELT(_obj,i),k))) & (j < (strsize[i])); j++) {
                     strbuf[z++] = CHAR(STRING_ELT(VECTOR_ELT(_obj,i),k))[j];
                 }
                 for (; j < strsize[i]; j++) {


### PR DESCRIPTION
My understanding is that the current approach attempts to avoid strings of length zero. However, by doing so, it prevents R from creating single character columns in a compound dataset (as a single character column automatically becomes a string of length 2). This is causing a problem for the interoperability with languages which have single character data types and attempt to map an H5 compound data type to a struct containing such a data type.