### PR TITLE
Support for writing raw datatype.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rhdf5
 Type: Package
 Title: R Interface to HDF5
-Version: 2.31.5
+Version: 2.31.6
 Authors@R: c(person("Bernd", "Fischer", role = c("aut")), 
         person("Gregoire", "Pau", role="aut"),
         person("Mike", "Smith", 

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -940,6 +940,12 @@ SEXP _H5Dwrite( SEXP _dataset_id, SEXP _buf, SEXP _file_space_id, SEXP _mem_spac
     hid_t dim_space_id = mem_space_id == H5S_ALL ? dataset_id : mem_space_id;
     
     switch(TYPEOF(_buf)) {
+    case RAWSXP :
+        mem_type_id = H5T_STD_U8LE;
+        if (native)
+            PERMUTE(_buf, RAW, dim_space_id);
+        buf = RAW(_buf);
+        break;
     case INTSXP :
         mem_type_id = H5T_NATIVE_INT;
         if (native)


### PR DESCRIPTION
hi,

i opened an [issue](https://github.com/Bioconductor/HDF5Array/issues/23) on the package `HDF5Array` to ask for support for the 'raw' datatype. This has been provided with the caveat that the `h5write()` function from the `rhdf5` package does not support the 'raw' datatype and for that reason the update to the `HDF5Array` package converts the data into 'integer' before calling `h5write()` but ideally `h5write()` should natively support the 'raw' datatype.

if i disable the coercion to integer described in that [issue](https://github.com/Bioconductor/HDF5Array/issues/23), then i get the following error with `rhdf5` 2.31.5:

```
suppressPackageStartupMessages(library(HDF5Array))
set.seed(123)
len <- sample(1:10000, size=10000, replace=TRUE)
val <- sample(0:255, size=10000, replace=TRUE)
rawrle <- Rle(as.raw(rep(val, len)))
rawrlearr <- RleArray(rawrle, dim=length(rawrle))
rawrlearrh5 <- writeHDF5Array(rawrlearr, "rawrlearr.h5", "rlearr") 
Error in H5Dwrite(h5dataset, obj, h5spaceMem = h5spaceMem, h5spaceFile = h5spaceFile) : 
  Writing 'raw' not supported.
```
this pull request fixes this error, having commented the integer coercion i mentioned in `HDF5Array`. however the resulting HDF5 file still has the same size as with the coercion, which makes me think that my update, while it fixes the error, it might be not sufficient to natively support the 'raw' datatype. i hope you can easily find whether the pull request is correct and what else should be modified to fully enable the support for the 'raw' datatype.

thanks!

robert.
