### PR TITLE
Preservation of NA values in logical datatypes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rhdf5
 Type: Package
 Title: R Interface to HDF5
-Version: 2.33.2
+Version: 2.33.3
 Authors@R: c(person("Bernd", "Fischer", role = c("aut")), 
         person("Mike", "Smith", 
             role=c("aut", "cre"), 

--- a/R/H5D.R
+++ b/R/H5D.R
@@ -99,6 +99,10 @@ H5Dread <- function( h5dataset, h5spaceFile=NULL, h5spaceMem=NULL, buf = NULL, c
   if (H5Aexists(h5obj=h5dataset, name="storage.mode")) {
     att = H5Aopen(h5obj=h5dataset, name="storage.mode")
     if (H5Aread(h5attribute=att) == "logical") {
+      na_idx <- which(res == -128)
+      if(any(na_idx)) {
+        res[na_idx] <- NA_integer_
+      }
       storage.mode(res) = "logical"
     }
     H5Aclose(att)

--- a/R/H5P.R
+++ b/R/H5P.R
@@ -878,7 +878,7 @@ H5Pset_fill_value <- function( h5plist, value ) {
   tid <- switch(storage.mode,
                 double = h5constants$H5T["H5T_IEEE_F64LE"],
                 integer = h5constants$H5T["H5T_STD_I32LE"],
-                logical = h5constants$H5T["H5T_STD_U8LE"],
+                logical = h5constants$H5T["H5T_STD_I8LE"],
                 character = {
                     tid <- H5Tcopy("H5T_C_S1")
                     size <- nchar(value)+1

--- a/R/h5create.R
+++ b/R/h5create.R
@@ -48,7 +48,7 @@ h5createGroup <- function(file, group) {
                     double = h5constants$H5T["H5T_IEEE_F64LE"],
                     integer = h5constants$H5T["H5T_STD_I32LE"],
                     integer64 = h5constants$H5T["H5T_STD_I64LE"],
-                    logical = h5constants$H5T["H5T_STD_U8LE"],
+                    logical = h5constants$H5T["H5T_STD_I8LE"],
                     raw = h5constants$H5T["H5T_STD_U8LE"],
                     character = {
                       tid <- H5Tcopy("H5T_C_S1")

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,7 +4,8 @@
 \section{Changes in version 2.34.0}{
   \subsection{NEW FEATURES}{
     \itemize{
-      \item Added support for read access to files in Amazon S3 buckets.
+      \item Added support for read access to files in Amazon S3 buckets 
+      (currently only available on non-Windows platforms).
       \item Included read and write support for dynamic compression filters 
       distributed in \pkg{rhdf5filters}.
     }
@@ -13,6 +14,9 @@
     \itemize{
       \item Fix bug in H5Dget_storage_size() where the wrong C function was 
       called.
+      \item \code{NA} values in logical datatypes are now preserved when 
+      written and read back into R 
+      (https://github.com/grimbough/rhdf5/issues/58).
     }
   }
 }

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -138,27 +138,43 @@ SEXP H5Dread_helper_INTEGER(hid_t dataset_id, hid_t file_space_id, hid_t mem_spa
     int warn = 0;
     int warn_double = 0;
     
+    /* 1-byte integers. Reading strategy is dependent on whether these 
+     * are signed or unsigned (RAWSXP vs INTSXP) */
     if(b == 1) {
-      
-      mem_type_id = H5T_NATIVE_UCHAR;
-      
       void * buf;
-      if (length(_buf) == 0) {
-        Rval = PROTECT(allocVector(RAWSXP, n));
-        buf = RAW(Rval);
+      if(sgn == H5T_SGN_NONE) {
+        
+        mem_type_id = H5T_NATIVE_UCHAR;
+        if (length(_buf) == 0) {
+          Rval = PROTECT(allocVector(RAWSXP, n));
+          buf = RAW(Rval);
+        } else {
+          buf = RAW(_buf);
+          Rval = _buf;
+        }
+        herr_t herr = H5Dread(dataset_id, mem_type_id, mem_space_id, file_space_id, H5P_DEFAULT, buf );
+        if (native)
+          PERMUTE(Rval, RAW, mem_space_id);
+        
       } else {
-        buf = RAW(_buf);
-        Rval = _buf;
+        
+        mem_type_id = H5T_NATIVE_INT32;
+        if (length(_buf) == 0) {
+          Rval = PROTECT(allocVector(INTSXP, n));
+          buf = INTEGER(Rval);
+        } else {
+          buf = INTEGER(_buf);
+          Rval = _buf;
+        }
+        herr_t herr = H5Dread(dataset_id, mem_type_id, mem_space_id, file_space_id, H5P_DEFAULT, buf );
+        if (native)
+          PERMUTE(Rval, INTEGER, mem_space_id);
+        
       }
-      herr_t herr = H5Dread(dataset_id, mem_type_id, mem_space_id, file_space_id, H5P_DEFAULT, buf );
-      
-      if (native)
-        PERMUTE(Rval, RAW, mem_space_id);
-      
       if (length(_buf) == 0) {
         setAttrib(Rval, R_DimSymbol, Rdim);
       }
-    
+      
     } else {
     if ( ((b >= 2) & (b < 4)) | ((b == 4) & (sgn == H5T_SGN_2))) {   // Read directly to R-integer without loss of data (short or signed int)
         if (cpdType < 0) {

--- a/src/H5P.c
+++ b/src/H5P.c
@@ -1050,7 +1050,7 @@ SEXP _H5Pset_fill_value( SEXP _plist_id, SEXP _type_id, SEXP _value ) {
         value = REAL(_value);
     } else if (type_id == H5T_STD_I32LE) {
         value = INTEGER(_value);
-    } else if (type_id == H5T_STD_U8LE) {
+    } else if (type_id == H5T_STD_I8LE) {
         value = LOGICAL(_value);
     } else {
         value = (void *)CHAR(STRING_ELT(_value, 0));

--- a/tests/testthat/test_h5read.R
+++ b/tests/testthat/test_h5read.R
@@ -7,7 +7,7 @@ context("h5read")
 set.seed(1234)
 A = 1L:7L;  
 B = matrix(1:18, ncol = 2); 
-C = c(TRUE, TRUE, FALSE)
+C = c(TRUE, TRUE, FALSE, NA)
 D = seq(0, 1, by=0.1)
 E = as.raw(sample(0:255, size = 5))
 attr(D, "scale") <- "centimeters"


### PR DESCRIPTION
- Switch to **signed** 8bit integers for logical
- Reading unsigned 8bit to RAWSXP, signed 8bit to INTSXP
- Post process logicals with -128 to NA

This pull request addresses #58 