### PR TITLE
fix Makevars. Rscript should be called with --slave 

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,4 @@
-RHDF5_LIBS = $(shell "$(R_HOME)/bin${R_ARCH_BIN}/Rscript" -e 'Rhdf5lib::pkgconfig("PKG_C_LIBS")')
+RHDF5_LIBS = $(shell "$(R_HOME)/bin${R_ARCH_BIN}/Rscript" --slave -e 'Rhdf5lib::pkgconfig("PKG_C_LIBS")')
 PKG_LIBS = $(RHDF5_LIBS)
 
 # uncomment below to print the contents of $(PKG_LIBS)


### PR DESCRIPTION
This ia a similar problem to [rhdf5filters:PR7](https://github.com/grimbough/rhdf5filters/pull/7). In this case, when Rscript is called within `Makevars` it should include the option `--slave`. If not implemented, then the installation fails because RHDF5_INCLUDE would include the entire welcome message. 