### PR TITLE
Support variable-length, UTF-8 encoded string datasets.

### DIFF
--- a/R/h5write.R
+++ b/R/h5write.R
@@ -137,8 +137,12 @@ h5writeDatasetHelper <- function (obj, h5dataset, index = NULL, start = NULL, st
 #'   table from python or with a struct-type from C. The disadvantage is that
 #'   the data has to be rearranged on disk and thus can slow down I/O. If fast
 #'   reading is required, `DataFrameAsCompound=FALSE` is recommended.
-#' @param size The length of string data type. Variable length strings are not
-#'   yet supported for datasets, only for attributes.
+#' @param size The length of the fixed-width string data type, when `obj` is a
+#'   character vector. If `NULL`, this is set to the length of the largest
+#'   string.
+#' @param variableLengthString Whether character vectors should be written as
+#'   variable-length strings into the attributes. If `TRUE`, `size` is ignored.
+#' @param encoding The encoding of the string data type.
 #' @param createnewfile If `TRUE`, a new file will be created if necessary.
 #' @param write.attributes (logical) If TRUE, all R-attributes attached to the
 #'   object \code{obj} are written to the HDF5 file.
@@ -298,31 +302,31 @@ h5writeDataset.raw       <- function(...) { h5writeDataset.array(...) }
 #' @export 
 h5writeDataset.array <- function(obj, h5loc, name, index = NULL, 
                                  start=NULL, stride=NULL, block=NULL, count=NULL, 
-                                 size=NULL, level=6) {
+                                 size=NULL, variableLengthString=FALSE, encoding=c("ASCII", "UTF-8"),
+                                 level=6) {
 
     exists <- try( { H5Lexists(h5loc, name) } )
     if (!exists) {
-        if (is.null(size)) {
-            if (storage.mode(obj) == "character") {
-                if (length(obj) > 0) {
-                    size <- max(nchar(obj), na.rm = TRUE)
-                    ## if any NA, the minimum string length is 2
-                    if(any(is.na(obj)) && size < 2) { size <- 2 }
-                    ## empty string gives size 0, and errors
-                    if(size == 0) { size <- 1 }
-                } else {
-                    size <- 1
-                }
-            }
-            if (is.null(dim(obj))) {
-                dim <- length(obj) 
+        if (storage.mode(obj) == "character" && !variableLengthString && is.null(size)) {
+            if (length(obj) > 0) {
+                size <- max(nchar(obj), na.rm = TRUE)
+                ## if any NA, the minimum string length is 2
+                if(any(is.na(obj)) && size < 2) { size <- 2 }
+                ## empty string gives size 0, and errors
+                if(size == 0) { size <- 1 }
             } else {
-                dim <- dim(obj)
-                if (h5loc@native) dim <- rev(dim)
+                size <- 1
             }
-            h5createDataset(h5loc, name, dim, storage.mode = storage.mode(obj), 
-                            size = size, chunk=dim, level=level) 
         }
+        if (is.null(dim(obj))) {
+            dim <- length(obj) 
+        } else {
+            dim <- dim(obj)
+            if (h5loc@native) dim <- rev(dim)
+        }
+        h5createDataset(h5loc, name, dim, storage.mode = storage.mode(obj), 
+                        size = size, encoding = match.arg(encoding),
+                        chunk=dim, level=level) 
     }
     h5dataset <- H5Dopen(h5loc, name)
     on.exit( H5Dclose(h5dataset) )


### PR DESCRIPTION
Following in the footsteps of #80:

```r
library(rhdf5)
unlink("ex_hdf5file.h5")
h5createFile("ex_hdf5file.h5")

# write a matrix
h5write(c("Aaron", "was", "here", "1"), "ex_hdf5file.h5","A", variableLengthString=TRUE)
h5write(c("Aaron", "was", "here", "2"), "ex_hdf5file.h5","B", variableLengthString=FALSE)
h5write(c("Aaron", "was", "here", "3"), "ex_hdf5file.h5","C", variableLengthString=TRUE, encoding="UTF8")
h5write(c("Aaron", "was", "here", "4"), "ex_hdf5file.h5","D", variableLengthString=FALSE, encoding="UTF8")

h5read("ex_hdf5file.h5", "A")
## [1] "Aaron" "was"   "here"  "1"    
h5read("ex_hdf5file.h5", "B")
## [1] "Aaron" "was"   "here"  "2"    
h5read("ex_hdf5file.h5", "C")
## [1] "Aaron" "was"   "here"  "3"    
h5read("ex_hdf5file.h5", "D")
## [1] "Aaron" "was"   "here"  "4"    
```

Looking at the `h5dump ex_hdf5file.h5`:

```
HDF5 "ex_hdf5file.h5" {
GROUP "/" {
   DATASET "A" {
      DATATYPE  H5T_STRING {
         STRSIZE H5T_VARIABLE;
         STRPAD H5T_STR_NULLPAD;
         CSET H5T_CSET_ASCII;
         CTYPE H5T_C_S1;
      }
      DATASPACE  SIMPLE { ( 4 ) / ( 4 ) }
      DATA {
      (0): "Aaron", "was", "here", "1"
      }
      ATTRIBUTE "rhdf5-NA.OK" {
         DATATYPE  H5T_STD_I32LE
         DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
         DATA {
         (0): 1
         }
      }
   }
   DATASET "B" {
      DATATYPE  H5T_STRING {
         STRSIZE 5;
         STRPAD H5T_STR_NULLPAD;
         CSET H5T_CSET_ASCII;
         CTYPE H5T_C_S1;
      }
      DATASPACE  SIMPLE { ( 4 ) / ( 4 ) }
      DATA {
      (0): "Aaron", "was\000\000", "here\000", "2\000\000\000\000"
      }
      ATTRIBUTE "rhdf5-NA.OK" {
         DATATYPE  H5T_STD_I32LE
         DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
         DATA {
         (0): 1
         }
      }
   }
   DATASET "C" {
      DATATYPE  H5T_STRING {
         STRSIZE H5T_VARIABLE;
         STRPAD H5T_STR_NULLPAD;
         CSET H5T_CSET_UTF8;
         CTYPE H5T_C_S1;
      }
      DATASPACE  SIMPLE { ( 4 ) / ( 4 ) }
      DATA {
      (0): "Aaron", "was", "here", "3"
      }
      ATTRIBUTE "rhdf5-NA.OK" {
         DATATYPE  H5T_STD_I32LE
         DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
         DATA {
         (0): 1
         }
      }
   }
   DATASET "D" {
      DATATYPE  H5T_STRING {
         STRSIZE 5;
         STRPAD H5T_STR_NULLPAD;
         CSET H5T_CSET_UTF8;
         CTYPE H5T_C_S1;
      }
      DATASPACE  SIMPLE { ( 4 ) / ( 4 ) }
      DATA {
      (0): "Aaron", "was\000\000", "here\000", "4\000\000\000\000"
      }
      ATTRIBUTE "rhdf5-NA.OK" {
         DATATYPE  H5T_STD_I32LE
         DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
         DATA {
         (0): 1
         }
      }
   }
}
}
```

... which verifies that it is, indeed, being stored as a variable length string.

Note that variable length strings do not seem to be compressed, so YMMV with respect to actual size savings.

Reoxygenation and implementation of unit tests is at your discretion.
