### PR TITLE
Expose per-class methods for h5writeAttribute. Fixes issue #98; PR 2 of 2.

### DIFF
--- a/R/h5writeAttr.R
+++ b/R/h5writeAttr.R
@@ -21,20 +21,26 @@ h5writeAttribute <- function(attr, h5obj, name, cset=c("ASCII", "UTF8"), variabl
   invisible(res)
 }
 
-#' @export
+#' @export h5writeAttribute.matrix
 h5writeAttribute.matrix <- function(...) { h5writeAttribute.array(...) }
-#' @export
+
+#' @export h5writeAttribute.integer
 h5writeAttribute.integer <- function(...) { h5writeAttribute.array(...) }
-#' @export
+
+#' @export h5writeAttribute.double
 h5writeAttribute.double <- function(...) { h5writeAttribute.array(...) }
-#' @export
+
+#' @export h5writeAttribute.logical
 h5writeAttribute.logical <- function(...) { h5writeAttribute.array(...) }
-#' @export
+
+#' @export h5writeAttribute.character
 h5writeAttribute.character <- function(...) { h5writeAttribute.array(...) }
-#' @export
+
+#' @export h5writeAttribute.default
 h5writeAttribute.default <- function(attr, h5obj, name, ...) { warning("No function found to write attribute of class '",class(attr),"'. Attribute '",name,"' is not written to hdf5-file.") }
 
 #' @rdname h5_writeAttribute
+#' @export h5writeAttribute.array
 h5writeAttribute.array <- function(attr, h5obj, name, cset=c("ASCII", "UTF8"), variableLengthString=FALSE, asScalar=FALSE) {
   if (asScalar) {
     if (length(attr) != 1L) {


### PR DESCRIPTION
Since these function names have a "." in them, roxygen will add them to NAMESPACE as e.g. `S3method(h5writeAttribute,integer)`. This PR will force oxygen to include them in NAMESPACE as e.g. `export(h5writeAttribute.integer)`, thereby restoring the exports present prior to PR #87.