### PR TITLE
Correctly save fixed-width strings with UTF8 encoding.

### DIFF
--- a/R/h5write.R
+++ b/R/h5write.R
@@ -309,15 +309,20 @@ h5writeDataset.array <- function(obj, h5loc, name, index = NULL,
 
     exists <- try( { H5Lexists(h5loc, name) } )
     if (!exists) {
-        if (storage.mode(obj) == "character" && !variableLengthString && is.null(size)) {
-            if (length(obj) > 0) {
-                size <- max(nchar(obj, type="byte"), na.rm = TRUE)
-                ## if any NA, the minimum string length is 2
-                if(any(is.na(obj)) && size < 2) { size <- 2 }
-                ## empty string gives size 0, and errors
-                if(size == 0) { size <- 1 }
-            } else {
-                size <- 1
+        if (storage.mode(obj) == "character") {
+            if (!variableLengthString && is.null(size)) {
+                if (length(obj) > 0) {
+                    size <- max(nchar(obj, type="byte"), na.rm = TRUE)
+                    ## if any NA, the minimum string length is 2
+                    if(any(is.na(obj)) && size < 2) { size <- 2 }
+                    ## empty string gives size 0, and errors
+                    if(size == 0) { size <- 1 }
+                } else {
+                    size <- 1
+                }
+            }
+            if (is.null(encoding)) {
+                encoding <- if (Encoding(obj) == "UTF-8") "UTF-8" else "ASCII"
             }
         }
         if (is.null(dim(obj))) {
@@ -325,9 +330,6 @@ h5writeDataset.array <- function(obj, h5loc, name, index = NULL,
         } else {
             dim <- dim(obj)
             if (h5loc@native) dim <- rev(dim)
-        }
-        if (is.null(encoding)) {
-            encoding <- if (Encoding(obj) == "UTF-8") "UTF-8" else "ASCII"
         }
         h5createDataset(h5loc, name, dim, storage.mode = storage.mode(obj), 
                         size = size, 

--- a/R/h5write.R
+++ b/R/h5write.R
@@ -311,7 +311,7 @@ h5writeDataset.array <- function(obj, h5loc, name, index = NULL,
     if (!exists) {
         if (storage.mode(obj) == "character" && !variableLengthString && is.null(size)) {
             if (length(obj) > 0) {
-                size <- max(nchar(obj), na.rm = TRUE)
+                size <- max(nchar(obj, type="byte"), na.rm = TRUE)
                 ## if any NA, the minimum string length is 2
                 if(any(is.na(obj)) && size < 2) { size <- 2 }
                 ## empty string gives size 0, and errors
@@ -325,6 +325,9 @@ h5writeDataset.array <- function(obj, h5loc, name, index = NULL,
         } else {
             dim <- dim(obj)
             if (h5loc@native) dim <- rev(dim)
+        }
+        if (is.null(encoding)) {
+            encoding <- if (Encoding(obj) == "UTF-8") "UTF-8" else "ASCII"
         }
         h5createDataset(h5loc, name, dim, storage.mode = storage.mode(obj), 
                         size = size, 

--- a/R/h5write.R
+++ b/R/h5write.R
@@ -322,7 +322,7 @@ h5writeDataset.array <- function(obj, h5loc, name, index = NULL,
                 }
             }
             if (is.null(encoding)) {
-                encoding <- if (Encoding(obj) == "UTF-8") "UTF-8" else "ASCII"
+                encoding <- if (any(Encoding(obj) == "UTF-8")) "UTF-8" else "ASCII"
             }
         }
         if (is.null(dim(obj))) {


### PR DESCRIPTION
Closes #111, e.g., 

```r
library(rhdf5)
h5createFile("ex_hdf5file.h5")
h5write("α ≤ 0.1", "ex_hdf5file.h5", "WHEE")
h5read("ex_hdf5file.h5")
## [1] "α ≤ 0.1"
```

Haven't written tests or updated the docs, will leave that to you.