### PR TITLE
enable remote H5Fopen

### DIFF
--- a/R/H5F.R
+++ b/R/H5F.R
@@ -52,6 +52,10 @@ H5Fcreate <- function(
   invisible(h5file)
 }
 
+
+
+
+
 #' Open an existing HDF5 file
 #'
 #' @details Possible values for the `flags` argument are `H5F_ACC_RDWR` and `H5F_ACC_RDONLY`.
@@ -67,14 +71,20 @@ H5Fcreate <- function(
 #' orientation. Using `native = TRUE` increases HDF5 file portability
 #' between programming languages. A file written with `native = TRUE`
 #' should also be opened for reading with `native = TRUE`.
+#' @param s3 Logical. If `TRUE`, the file specified in `name` is read using
+#' the HDF5 Read-Only S3 virtual file driver. Requires that **Rhdf5lib** was
+#' compiled with S3 support, and that `name` is an `http://` or `https://` URL.
+#' @param s3credentials A list of length three containing the AWS region, access
+#' key ID, and secret access key for accessing files in a private S3 bucket.
+#' Leave as `NULL` for anonymous access to public data.
 #'
 #' @export
-H5Fopen <- function(
-  name,
-  flags = h5default("H5F_ACC_RD"),
-  fapl = NULL,
-  native = FALSE
-) {
+H5Fopen <- function(name,
+                    flags = h5default("H5F_ACC_RD"),
+                    fapl = NULL,
+                    native = FALSE,
+                    s3 = FALSE,
+                    s3credentials = NULL) {
   if (length(name) != 1 || !is.character(name)) {
     stop("'name' must be a character string of length 1")
   }
@@ -82,15 +92,18 @@ H5Fopen <- function(
     name <- normalizePath(name, mustWork = FALSE)
   }
   flags <- h5checkConstants("H5F_ACC_RD", flags)
-
   if (is.null(fapl)) {
-    ## create a new file access property list
     fapl <- H5Pcreate("H5P_FILE_ACCESS")
     on.exit(H5Pclose(fapl))
+    if (isTRUE(s3)) {
+      H5Pset_fapl_ros3(fapl, s3credentials)
+    }
   } else {
     fapl <- h5checktypeAndPLC(fapl, "H5P_FILE_ACCESS", allowNULL = FALSE)
+    if (isTRUE(s3)) {
+      warning("Ignoring s3 = TRUE because an explicit fapl was supplied")
+    }
   }
-
   fid <- .Call("_H5Fopen", name, flags, fapl@ID, PACKAGE = "rhdf5")
   if (fid > 0) {
     h5file <- new("H5IdComponent", ID = fid, native = native)
@@ -100,6 +113,7 @@ H5Fopen <- function(
   }
   invisible(h5file)
 }
+
 
 #' Close access to an HDF5 file
 #'

--- a/man/H5Fopen.Rd
+++ b/man/H5Fopen.Rd
@@ -4,7 +4,14 @@
 \alias{H5Fopen}
 \title{Open an existing HDF5 file}
 \usage{
-H5Fopen(name, flags = h5default("H5F_ACC_RD"), fapl = NULL, native = FALSE)
+H5Fopen(
+  name,
+  flags = h5default("H5F_ACC_RD"),
+  fapl = NULL,
+  native = FALSE,
+  s3 = FALSE,
+  s3credentials = NULL
+)
 }
 \arguments{
 \item{name}{The name (or path) of the HDF5 file to be opened.}
@@ -19,6 +26,14 @@ objects are treated as stored in HDF5 row-major rather than R column-major
 orientation. Using \code{native = TRUE} increases HDF5 file portability
 between programming languages. A file written with \code{native = TRUE}
 should also be opened for reading with \code{native = TRUE}.}
+
+\item{s3}{Logical. If \code{TRUE}, the file specified in \code{name} is read using
+the HDF5 Read-Only S3 virtual file driver. Requires that \strong{Rhdf5lib} was
+compiled with S3 support, and that \code{name} is an \verb{http://} or \verb{https://} URL.}
+
+\item{s3credentials}{A list of length three containing the AWS region, access
+key ID, and secret access key for accessing files in a private S3 bucket.
+Leave as \code{NULL} for anonymous access to public data.}
 }
 \description{
 Open an existing HDF5 file


### PR DESCRIPTION
I was able to add s3/s3credentials to H5open 


```R
# Build the FAPL by hand, exactly as the s3-aware path would
fapl <- H5Pcreate("H5P_FILE_ACCESS")
H5Pset_fapl_ros3(fapl)  # no credentials → anonymous mode
fid <- H5Fopen("https://thredds.nci.org.au/thredds/fileServer/gb6/BRAN/BRAN2023/daily/ocean_temp_2010_01.nc",
               flags = "H5F_ACC_RDONLY",
               fapl = fapl)
fid

fid
HDF5 FILE
        name /
    filename

             name       otype  dclass                   dim
0  Time           H5I_DATASET FLOAT   31
1  Time_bnds      H5I_DATASET FLOAT   2 x 31
2  average_DT     H5I_DATASET FLOAT   31
3  average_T1     H5I_DATASET FLOAT   31
4  average_T2     H5I_DATASET FLOAT   31
5  nv             H5I_DATASET FLOAT   2
6  st_edges_ocean H5I_DATASET FLOAT   52
7  st_ocean       H5I_DATASET FLOAT   51
8  temp           H5I_DATASET INTEGER 3600 x 1500 x 51 x 31
9  xt_ocean       H5I_DATASET FLOAT   3600
10 yt_ocean       H5I_DATASET FLOAT   1500
```

also works on these public sources

```R
fid <- H5Fopen("https://www.ncei.noaa.gov/data/sea-surface-temperature-optimum-interpolation/v2.1/access/avhrr/198109/oisst-avhrr-v02r01.19810901.nc", flags = "H5F_ACC_RDONLY",fapl = fapl)
> fid
HDF5 FILE
        name /
    filename

  name       otype  dclass                dim
0 anom H5I_DATASET INTEGER 1440 x 720 x 1 x 1
1 err  H5I_DATASET INTEGER 1440 x 720 x 1 x 1
2 ice  H5I_DATASET INTEGER 1440 x 720 x 1 x 1
3 lat  H5I_DATASET FLOAT   720
4 lon  H5I_DATASET FLOAT   1440
5 sst  H5I_DATASET INTEGER 1440 x 720 x 1 x 1
6 time H5I_DATASET FLOAT   1
7 zlev H5I_DATASET FLOAT   1


```

is a bit different on github: 

```R
fapl <- H5Pcreate("H5P_FILE_ACCESS")
H5Pset_fapl_ros3(fapl)
fid <- H5Fopen(
  "https://raw.githubusercontent.com/OSGeo/gdal/master/autotest/gdrivers/data/hdf5/dummy_HDFEOS_swath_chunked.h5",
  flags = "H5F_ACC_RDONLY",
  fapl = fapl
)
fid
HDF5 FILE
        name /
    filename

                name     otype dclass dim
0 HDFEOS             H5I_GROUP
1 HDFEOS INFORMATION H5I_GROUP
```

I haven't tested any credendtial-required sources. 