### PR TITLE
Don't warn about NA for non-character datasets

### DIFF
--- a/R/h5write.R
+++ b/R/h5write.R
@@ -406,7 +406,9 @@ h5writeDataset.array <- function(
     on.exit(H5Dclose(h5dataset))
     type <- H5Dget_type(h5dataset)
     variableLengthString <- H5Tis_variable_str(type)
-    if (!variableLengthString && anyNA(obj)) {
+    if (
+      storage.mode(obj) == "character" && !variableLengthString && anyNA(obj)
+    ) {
       warning(
         "Writing NA_character_ in fixed-length string datasets is fragile ",
         "and deprecated.\n",

--- a/tests/testthat/test_h5write.R
+++ b/tests/testthat/test_h5write.R
@@ -332,3 +332,35 @@ test_that("Writing NA_character_ as fixed-length string is deprecated", {
   )
   H5Fclose(fid)
 })
+
+test_that("No NA_character_ warning for non-character datasets", {
+  fid <- H5Fcreate(name = h5File)
+
+  # dataset created beforehand
+  h5createDataset(
+    file = fid,
+    dataset = "numeric_na",
+    dims = 3,
+    storage.mode = "double"
+  )
+  expect_no_warning(
+    h5writeDataset(obj = c(1, NA, 3), h5loc = fid, name = "numeric_na")
+  )
+  h5createDataset(
+    file = fid,
+    dataset = "integer_na",
+    dims = 3,
+    storage.mode = "integer"
+  )
+  expect_no_warning(
+    h5writeDataset(obj = c(1L, NA, 3L), h5loc = fid, name = "integer_na")
+  )
+
+  # dataset created on the fly
+  expect_no_warning(
+    h5writeDataset(obj = c(1, NaN, 3), h5loc = fid, name = "numeric_nan")
+  )
+  H5Fclose(fid)
+
+  expect_true(is.na(h5read(h5File, "numeric_na")[2]))
+})


### PR DESCRIPTION
Fixes #241

h5writeDataset.array() checks anyNA(obj) without checking that obj is character, so numeric data containing NA/NaN triggers a warning only relevant for character data types.
